### PR TITLE
remove unchecked block to `++i`

### DIFF
--- a/contracts/oracle/CurveTricryptoOracle.sol
+++ b/contracts/oracle/CurveTricryptoOracle.sol
@@ -86,14 +86,11 @@ contract CurveTricryptoOracle is CurveBaseOracle {
 
     function cubicRoot(uint256 x) internal pure returns (uint256) {
         uint256 D = x / 1e18;
-        for (uint256 i; i < 255; ) {
+        for (uint256 i; i < 255; ++i) {
             uint256 D_prev = D;
             D = (D * (2e18 + ((((x / D) * 1e18) / D) * 1e18) / D)) / (3e18);
             uint256 diff = (D > D_prev) ? D - D_prev : D_prev - D;
             if (diff < 2 || diff * 1e18 < D) return D;
-            unchecked {
-                ++i;
-            }
         }
         revert("Did Not Converge");
     }

--- a/contracts/spell/AuraSpell.sol
+++ b/contracts/spell/AuraSpell.sol
@@ -149,13 +149,10 @@ contract AuraSpell is BasicSpell {
             );
             /// Distribute the multiple rewards to users.
             uint256 rewardTokensLength = rewardTokens.length;
-            for (uint256 i; i != rewardTokensLength; ) {
+            for (uint256 i; i != rewardTokensLength; ++i) {
                 _doRefundRewards(
                     rewardTokens[i] == STASH_AURA ? AURA : rewardTokens[i]
                 );
-                unchecked {
-                    ++i;
-                }
             }
         }
 
@@ -272,7 +269,7 @@ contract AuraSpell is BasicSpell {
         uint256[] memory amountsIn = new uint256[](length);
         bool isLPIncluded;
 
-        for (i; i != length; ) {
+        for (i; i != length; ++i) {
             if (tokens[i] != lpToken) {
                 amountsIn[j] = IERC20(tokens[i]).balanceOf(address(this));
                 if (amountsIn[j] > 0) {
@@ -281,10 +278,6 @@ contract AuraSpell is BasicSpell {
                 }
                 ++j;
             } else isLPIncluded = true;
-
-            unchecked {
-                ++i;
-            }
         }
 
         if (isLPIncluded) {
@@ -314,7 +307,7 @@ contract AuraSpell is BasicSpell {
         uint256[] memory minAmountsOut = new uint256[](length);
         uint256 exitTokenIndex;
 
-        for (uint256 i; i != length; ) {
+        for (uint256 i; i != length; ++i) {
             if (tokens[i] == borrowToken) {
                 minAmountsOut[i] = amountOutMin;
                 break;
@@ -322,9 +315,6 @@ contract AuraSpell is BasicSpell {
 
             if (tokens[i] != lpToken) ++exitTokenIndex;
 
-            unchecked {
-                ++i;
-            }
         }
 
         return (minAmountsOut, tokens, exitTokenIndex);
@@ -336,7 +326,7 @@ contract AuraSpell is BasicSpell {
         bytes[] calldata swapDatas
     ) internal {
         uint256 rewardTokensLength = rewardTokens.length;
-        for (uint256 i; i != rewardTokensLength; ) {
+        for (uint256 i; i != rewardTokensLength; ++i) {
             address sellToken = rewardTokens[i];
             if (sellToken == STASH_AURA) sellToken = AURA;
 
@@ -354,10 +344,6 @@ contract AuraSpell is BasicSpell {
 
             /// Refund rest (dust) amount to owner
             _doRefund(sellToken);
-
-            unchecked {
-                ++i;
-            }
         }
     }
 }

--- a/contracts/wrapper/WAuraPools.sol
+++ b/contracts/wrapper/WAuraPools.sol
@@ -332,7 +332,7 @@ contract WAuraPools is
         rewards[1] = _getAllocatedAURA(pid, stAuraPerShare, amount);
 
         /// Additional rewards
-        for (uint256 i; i != extraRewardsCount; ) {
+        for (uint256 i; i != extraRewardsCount; ++i) {
             address rewarder = extraRewards[pid][i];
             uint256 stRewardPerShare = accExtPerShare[tokenId][rewarder];
             tokens[i + 2] = IAuraRewarder(rewarder).rewardToken();
@@ -345,10 +345,6 @@ contract WAuraPools is
                     amount,
                     lpDecimals
                 );
-            }
-
-            unchecked {
-                ++i;
             }
         }
     }
@@ -384,7 +380,7 @@ contract WAuraPools is
         /// Store extra rewards info
         uint256 extraRewardsCount = IAuraRewarder(auraRewarder)
             .extraRewardsLength();
-        for (uint256 i; i != extraRewardsCount; ) {
+        for (uint256 i; i != extraRewardsCount; ++i) {
             address extraRewarder = IAuraRewarder(auraRewarder).extraRewards(i);
             uint256 rewardPerToken = IAuraRewarder(extraRewarder)
                 .rewardPerToken();
@@ -393,10 +389,6 @@ contract WAuraPools is
                 : rewardPerToken;
 
             _syncExtraReward(pid, extraRewarder);
-
-            unchecked {
-                ++i;
-            }
         }
 
         auraPerShareDebt[id] = auraPerShareByPid[pid];
@@ -440,12 +432,9 @@ contract WAuraPools is
         uint256 extraRewardsCount = IAuraRewarder(auraRewarder)
             .extraRewardsLength();
 
-        for (uint256 i; i != extraRewardsCount; ) {
+        for (uint256 i; i != extraRewardsCount; ++i) {
             _syncExtraReward(pid, IAuraRewarder(auraRewarder).extraRewards(i));
 
-            unchecked {
-                ++i;
-            }
         }
         uint256 storedExtraRewardLength = extraRewards[pid].length;
         bool hasDiffExtraRewards = extraRewardsCount != storedExtraRewardLength;
@@ -454,25 +443,19 @@ contract WAuraPools is
 
         /// Withdraw manually
         if (hasDiffExtraRewards) {
-            for (uint256 i; i != storedExtraRewardLength; ) {
+            for (uint256 i; i != storedExtraRewardLength; ++i) {
                 IAuraExtraRewarder(extraRewards[pid][i]).getReward();
 
-                unchecked {
-                    ++i;
-                }
             }
         }
 
         uint256 rewardTokensLength = rewardTokens.length;
-        for (uint256 i; i != rewardTokensLength; ) {
+        for (uint256 i; i != rewardTokensLength; ++i) {
             if (rewards[i] != 0) {
                 address rewardToken = rewardTokens[i];
                 IERC20Upgradeable(
                     rewardToken == STASH_AURA ? address(AURA) : rewardToken
                 ).safeTransfer(msg.sender, rewards[i]);
-            }
-            unchecked {
-                ++i;
             }
         }
     }

--- a/contracts/wrapper/WConvexPools.sol
+++ b/contracts/wrapper/WConvexPools.sol
@@ -253,7 +253,7 @@ contract WConvexPools is
         tokens[1] = address(CVX);
         rewards[1] = _getAllocatedCVX(pid, stCrvPerShare, amount);
 
-        for (uint256 i; i < extraRewardsCount; ) {
+        for (uint256 i; i < extraRewardsCount; ++i) {
             address rewarder = extraRewards[pid][i];
             uint256 stRewardPerShare = accExtPerShare[tokenId][rewarder];
             tokens[i + 2] = IRewarder(rewarder).rewardToken();
@@ -268,10 +268,6 @@ contract WConvexPools is
                     amount,
                     lpDecimals
                 );
-            }
-
-            unchecked {
-                ++i;
             }
         }
     }
@@ -303,7 +299,7 @@ contract WConvexPools is
         _mint(msg.sender, id, amount, "");
         /// Store extra rewards info
         uint256 extraRewardsCount = IRewarder(cvxRewarder).extraRewardsLength();
-        for (uint256 i; i < extraRewardsCount; ) {
+        for (uint256 i; i < extraRewardsCount; ++i) {
             address extraRewarder = IRewarder(cvxRewarder).extraRewards(i);
             uint256 rewardPerToken = IRewarder(extraRewarder).rewardPerToken();
             accExtPerShare[id][extraRewarder] = rewardPerToken == 0
@@ -311,10 +307,6 @@ contract WConvexPools is
                 : rewardPerToken;
 
             _syncExtraReward(pid, extraRewarder);
-
-            unchecked {
-                ++i;
-            }
         }
 
         cvxPerShareDebt[id] = cvxPerShareByPid[pid];
@@ -356,12 +348,9 @@ contract WConvexPools is
 
         uint256 extraRewardsCount = IRewarder(cvxRewarder).extraRewardsLength();
 
-        for (uint256 i; i < extraRewardsCount; ) {
+        for (uint256 i; i < extraRewardsCount; ++i) {
             _syncExtraReward(pid, IRewarder(cvxRewarder).extraRewards(i));
 
-            unchecked {
-                ++i;
-            }
         }
         uint256 storedExtraRewardLength = extraRewards[pid].length;
         bool hasDiffExtraRewards = extraRewardsCount != storedExtraRewardLength;
@@ -370,25 +359,17 @@ contract WConvexPools is
 
         /// Withdraw manually
         if (hasDiffExtraRewards) {
-            for (uint256 i; i < storedExtraRewardLength; ) {
+            for (uint256 i; i < storedExtraRewardLength; ++i) {
                 ICvxExtraRewarder(extraRewards[pid][i]).getReward();
-
-                unchecked {
-                    ++i;
-                }
             }
         }
 
         uint256 rewardLen = rewardTokens.length;
-        for (uint256 i; i < rewardLen; ) {
+        for (uint256 i; i < rewardLen; ++i) {
             IERC20Upgradeable(rewardTokens[i]).safeTransfer(
                 msg.sender,
                 rewards[i]
             );
-
-            unchecked {
-                ++i;
-            }
         }
     }
 


### PR DESCRIPTION
Given the updates to the solidity version from `0.8.16` -> `0.8.22` There is no longer a need to have the unchecked block for ++i instead can have that inlined. This PR should be merged prior to [PR 107](https://github.com/Blueberryfi/blueberry-core/pull/107) being merged.