### PR TITLE
_doBorrow optimized

### DIFF
--- a/contracts/spell/BasicSpell.sol
+++ b/contracts/spell/BasicSpell.sol
@@ -358,9 +358,12 @@ abstract contract BasicSpell is ERC1155NaiveReceiver, OwnableUpgradeable {
     function _doBorrow(address token, uint256 amount) internal returns (uint256 borrowedAmount) {
         if (amount > 0) {
             bool isETH = IERC20(token).isETH();
-            borrowedAmount = bank.borrow(isETH ? WETH : token, amount);
+            
             if (isETH) {
+                borrowedAmount = bank.borrow(WETH, amount);
                 IWETH(WETH).withdraw(borrowedAmount);
+            } else {
+                borrowedAmount = bank.borrow(token, amount);
             }
         }
     }


### PR DESCRIPTION
Within `_doBorrow`  in `BasicSpell`  there multiple comparisons of if a token is ETH or a regular ERC20. This can be cut down to a single comparison to save gas. `_doRepay` faced similar issues and was optimized in PR #108.