### PR TITLE
Documentation and Visibility: Balancer Oracles

### DIFF
--- a/contracts/interfaces/balancer-v2/IBalancerV2StablePool.sol
+++ b/contracts/interfaces/balancer-v2/IBalancerV2StablePool.sol
@@ -2,7 +2,7 @@
 
 pragma solidity 0.8.22;
 
-import "./IBalancerV2Pool.sol";
+import { IBalancerV2Pool } from "./IBalancerV2Pool.sol";
 
 interface IBalancerV2StablePool is IBalancerV2Pool {
     function getRate() external view returns (uint256);

--- a/contracts/interfaces/balancer-v2/IBalancerV2WeightedPool.sol
+++ b/contracts/interfaces/balancer-v2/IBalancerV2WeightedPool.sol
@@ -2,7 +2,7 @@
 
 pragma solidity 0.8.22;
 
-import "./IBalancerV2Pool.sol";
+import { IBalancerV2Pool } from "./IBalancerV2Pool.sol";
 
 interface IBalancerV2WeightedPool is IBalancerV2Pool {
     function getNormalizedWeights() external view returns (uint256[] memory);

--- a/contracts/oracle/StableBPTOracle.sol
+++ b/contracts/oracle/StableBPTOracle.sol
@@ -32,7 +32,9 @@ import { IRateProvider } from "../interfaces/balancer-v2/IRateProvider.sol";
 contract StableBPTOracle is UsingBaseOracle, Ownable2StepUpgradeable, IBaseOracle {
     using FixedPoint for uint256;
 
-    IBaseOracle public weightedPoolOracle;
+    /// @dev Address of the weighted pool oracle
+    IBaseOracle private _weightedPoolOracle;
+    /// @dev Address of the Balancer Vault
     IBalancerVault private immutable _VAULT;
 
     // Protects the oracle from being manipulated via read-only reentrancy
@@ -45,6 +47,12 @@ contract StableBPTOracle is UsingBaseOracle, Ownable2StepUpgradeable, IBaseOracl
                                      CONSTRUCTOR
     //////////////////////////////////////////////////////////////////////////*/
 
+    /**
+     * @notice Constructs a new instance of the contract.
+     * @param vault Instance of the Balancer V2 Vault
+     * @param base The base oracle instance.
+     * @param owner Address of the owner of the contract.
+     */
     constructor(IBalancerVault vault, IBaseOracle base, address owner) UsingBaseOracle(base) Ownable2StepUpgradeable() {
         _VAULT = vault;
         _transferOwnership(owner);
@@ -54,10 +62,7 @@ contract StableBPTOracle is UsingBaseOracle, Ownable2StepUpgradeable, IBaseOracl
                                       FUNCTIONS
     //////////////////////////////////////////////////////////////////////////*/
 
-    /**
-     * @notice Return the USD value of given Balancer Lp, with 18 decimals of precision.
-     * @param token The ERC-20 token to check the value.
-     */
+    /// @inheritdoc IBaseOracle
     function getPrice(address token) public override balancerNonReentrant returns (uint256) {
         uint256 minPrice;
         IBalancerV2StablePool pool = IBalancerV2StablePool(token);
@@ -100,13 +105,19 @@ contract StableBPTOracle is UsingBaseOracle, Ownable2StepUpgradeable, IBaseOracl
     function setWeightedPoolOracle(address oracle) external onlyOwner {
         if (oracle == address(0)) revert Errors.ZERO_ADDRESS();
 
-        weightedPoolOracle = IBaseOracle(oracle);
+        _weightedPoolOracle = IBaseOracle(oracle);
+    }
+
+    /// @notice Returns the weighted pool oracle address
+    function getWeightedPoolOracle() external view returns (address) {
+        return address(_weightedPoolOracle);
     }
 
     /**
      * @notice Returns the minimum price of a given array of tokens
      * @param tokens An array of tokens within the pool
      * @param rateProviders An array of rate providers associated with the tokens in the pool
+     * @return The minimum price of the given array of tokens
      */
     function _getTokensMinPrice(address[] memory tokens, address[] memory rateProviders) internal returns (uint256) {
         uint256 minPrice;
@@ -131,6 +142,7 @@ contract StableBPTOracle is UsingBaseOracle, Ownable2StepUpgradeable, IBaseOracl
      * @notice Returns the price of a given token
      * @param rateProvider The rate provider associated with the token
      * @param minCandidate The token to calculate the minimum price for
+     * @return The price of the given token
      */
     function _calculateMinCandidatePrice(IRateProvider rateProvider, address minCandidate) internal returns (uint256) {
         uint256 minCandidatePrice = _getMarketPrice(minCandidate);
@@ -148,12 +160,13 @@ contract StableBPTOracle is UsingBaseOracle, Ownable2StepUpgradeable, IBaseOracl
      * @dev If the token is not supported by the base oracle, we assume that it is a nested pool
      *    and we will try to get the price from the weighted pool oracle or recursively
      * @param token Address of the token to fetch the price for.
+     * @return The Market price of the given token
      */
     function _getMarketPrice(address token) internal returns (uint256) {
         try base.getPrice(token) returns (uint256 price) {
             return price;
         } catch {
-            try weightedPoolOracle.getPrice(token) returns (uint256 price) {
+            try _weightedPoolOracle.getPrice(token) returns (uint256 price) {
                 return price;
             } catch {
                 return getPrice(token);

--- a/contracts/oracle/WeightedBPTOracle.sol
+++ b/contracts/oracle/WeightedBPTOracle.sol
@@ -32,12 +32,14 @@ import { IBalancerVault } from "../interfaces/balancer-v2/IBalancerVault.sol";
 contract WeightedBPTOracle is UsingBaseOracle, Ownable2StepUpgradeable, IBaseOracle {
     using FixedPoint for uint256;
 
-    IBaseOracle public stablePoolOracle;
-    IBalancerVault public immutable VAULT;
+    /// @notice Stable pool oracle
+    IBaseOracle private _stablePoolOracle;
+    /// @notice Balancer Vault
+    IBalancerVault private immutable _VAULT;
 
     // Protects the oracle from being manipulated via read-only reentrancy
     modifier balancerNonReentrant() {
-        VaultReentrancyLib.ensureNotInVaultContext(VAULT);
+        VaultReentrancyLib.ensureNotInVaultContext(_VAULT);
         _;
     }
 
@@ -45,27 +47,26 @@ contract WeightedBPTOracle is UsingBaseOracle, Ownable2StepUpgradeable, IBaseOra
                                      CONSTRUCTOR
     //////////////////////////////////////////////////////////////////////////*/
 
-    constructor(
-        IBalancerVault _vault,
-        IBaseOracle _base,
-        address _owner
-    ) UsingBaseOracle(_base) Ownable2StepUpgradeable() {
-        VAULT = _vault;
-        _transferOwnership(_owner);
+    /**
+     * @notice Constructs a new instance of the contract.
+     * @param vault Instance of the Balancer V2 Vault
+     * @param base The base oracle instance.
+     * @param owner Address of the owner of the contract.
+     */
+    constructor(IBalancerVault vault, IBaseOracle base, address owner) UsingBaseOracle(base) Ownable2StepUpgradeable() {
+        _VAULT = vault;
+        _transferOwnership(owner);
     }
 
     /*//////////////////////////////////////////////////////////////////////////
                                       FUNCTIONS
     //////////////////////////////////////////////////////////////////////////*/
 
-    /**
-     * @notice Return the USD value of given Balancer Lp, with 18 decimals of precision.
-     * @param token The ERC-20 token to check the value.
-     */
+    /// @inheritdoc IBaseOracle
     function getPrice(address token) public override balancerNonReentrant returns (uint256) {
         IBalancerV2WeightedPool pool = IBalancerV2WeightedPool(token);
 
-        (address[] memory tokens, , ) = VAULT.getPoolTokens(pool.getPoolId());
+        (address[] memory tokens, , ) = _VAULT.getPoolTokens(pool.getPoolId());
 
         uint256[] memory weights = pool.getNormalizedWeights();
 
@@ -92,7 +93,12 @@ contract WeightedBPTOracle is UsingBaseOracle, Ownable2StepUpgradeable, IBaseOra
     function setStablePoolOracle(address oracle) external onlyOwner {
         if (oracle == address(0)) revert Errors.ZERO_ADDRESS();
 
-        stablePoolOracle = IBaseOracle(oracle);
+        _stablePoolOracle = IBaseOracle(oracle);
+    }
+
+    /// @notice Returns the stable pool oracle address
+    function getStablePoolOracle() external view returns (address) {
+        return address(_stablePoolOracle);
     }
 
     /**
@@ -100,12 +106,13 @@ contract WeightedBPTOracle is UsingBaseOracle, Ownable2StepUpgradeable, IBaseOra
      * @dev If the token is not supported by the base oracle, we assume that it is a nested pool
      *    and we will try to get the price from the stable pool oracle or recursively
      * @param token Address of the token to fetch the price for.
+     * @return The Market price of the given token
      */
     function _getMarketPrice(address token) internal returns (uint256) {
         try base.getPrice(token) returns (uint256 price) {
             return price;
         } catch {
-            try stablePoolOracle.getPrice(token) returns (uint256 price) {
+            try _stablePoolOracle.getPrice(token) returns (uint256 price) {
                 return price;
             } catch {
                 return getPrice(token);


### PR DESCRIPTION
# Description

This PR adds proper documentation formatting and changes all public variables to private in both `StableBPTOracle` and `WeightedBPTOracle`. 

- Public getters for `getStablePoolOracle` and `getWeightedPoolOracle`. No public getter was added for `_VAULT`. Please comment if you think there should be one.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [x] Code refactor / cleanup
- [x] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests are included for all code paths
- [x] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->