### PR TITLE
Erc4626 Oracle

### DIFF
--- a/constant.ts
+++ b/constant.ts
@@ -75,6 +75,7 @@ export enum CONTRACT_NAMES {
   AuraLiquidator = 'AuraLiquidator',
   ConvexLiquidator = 'ConvexLiquidator',
   SoftVaultOracle = 'SoftVaultOracle',
+  ERC4626Oracle = 'ERC4626Oracle',
 }
 
 export const ADDRESS_GOERLI = {
@@ -165,6 +166,7 @@ export const ADDRESS = {
   wstETH: '0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0',
   stETH: '0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84',
   ankrETH: '0xE95A203B1a91a908F9B9CE46459d101078c2c3cb',
+  pxETH: '0x04C154b66CB340F3Ae24111CC767e0184Ed00Cc6',
   bUSDC: '0xdfd54ac444eEffc121E3937b4EAfc3C27d39Ae64',
   bICHI: '0xBDf1431c153A2A48Ee05C1F24b9Dc476C93F75aE',
   bDAI: '0xcB5C1909074C7ac1956DdaFfA1C2F1cbcc67b932',
@@ -173,6 +175,7 @@ export const ADDRESS = {
   bWBTC: '0x506c190340F786c65548C0eE17c5EcDbba7807e0',
   bWETH: '0x8E09cC1d00c9bd67f99590E1b2433bF4Db5309C3',
   bALCX: '', // TODO: update address after mainnet deploy
+  apxETH: '0x9Ba021B0a9b958B5E75cE9f6dff97C7eE52cb3E6',
   bOHM: '', // TODO: update address after mainnet deploy
   bMIM: '', // TODO: update address after mainnet deploy
   bBAL: '', // TODO: update address after mainnet deploy
@@ -344,8 +347,9 @@ export const DEPLOYMENTS = {
   ibWBTC: '0xCc40ffD2512101c049A62eCE218AA2b5Aa6D2560',
   ibWETH: '0xcCd438a78376955A3b174be619E50Aa3DdD65469',
   ibWSTETH: '0x8DE384d5407ca3477b338Ee7a392caFFDD889F2D',
-  coreOracle: '0xdfe469ACe05C3d0D4461439e6cF5d0f46F33Ec56'
-}
+  coreOracle: '0xdfe469ACe05C3d0D4461439e6cF5d0f46F33Ec56',
+  chainlinkAdapterOracle: '0xC5CEa3f9C92291335076D4C2eC6Ae72E45Fb8937',
+};
 
 export const ADDRESS_DEV = {
   bUSDC: '0x5554dFB8aEbC5A148286fFAF2F84E584b43fF213',

--- a/contracts/interfaces/IApxETH.sol
+++ b/contracts/interfaces/IApxETH.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.22;
+
+interface IApxEth {
+    function assetsPerShare() external view returns (uint256);
+}

--- a/contracts/oracle/ERC4626Oracle.sol
+++ b/contracts/oracle/ERC4626Oracle.sol
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: MIT
+/*
+██████╗ ██╗     ██╗   ██╗███████╗██████╗ ███████╗██████╗ ██████╗ ██╗   ██╗
+██╔══██╗██║     ██║   ██║██╔════╝██╔══██╗██╔════╝██╔══██╗██╔══██╗╚██╗ ██╔╝
+██████╔╝██║     ██║   ██║█████╗  ██████╔╝█████╗  ██████╔╝██████╔╝ ╚████╔╝
+██╔══██╗██║     ██║   ██║██╔══╝  ██╔══██╗██╔══╝  ██╔══██╗██╔══██╗  ╚██╔╝
+██████╔╝███████╗╚██████╔╝███████╗██████╔╝███████╗██║  ██║██║  ██║   ██║
+╚═════╝ ╚══════╝ ╚═════╝ ╚══════╝╚═════╝ ╚══════╝╚═╝  ╚═╝╚═╝  ╚═╝   ╚═╝
+*/
+
+pragma solidity 0.8.22;
+
+import { IERC20Metadata } from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
+import { IERC4626 } from "@openzeppelin/contracts/token/ERC20/extensions/ERC4626.sol";
+
+import "../utils/BlueberryConst.sol" as Constants;
+import "../utils/BlueberryErrors.sol" as Errors;
+
+import { UsingBaseOracle } from "./UsingBaseOracle.sol";
+
+import { IApxEth } from "../interfaces/IApxETH.sol";
+import { IBaseOracle } from "../interfaces/IBaseOracle.sol";
+
+/**
+ * @title ERC4626Oracle
+ * @author BlueberryProtocol
+ * @notice Oracle contract which privides price feeds of token vaults that conform to the ERC4626 standard
+ */
+contract ERC4626Oracle is IBaseOracle, UsingBaseOracle {
+    /*//////////////////////////////////////////////////////////////////////////
+                                      STRUCTS 
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /**
+     * @dev Struct to store token info related to the ERC4626 Token
+     * @param underlyingToken The base ERC20 token associated with the ERC4626 token
+     * @param underlyingDecimals The decimals of the underlying token
+     * @param erc4626Decimals The decimals of the ERC4626 token
+     */
+    struct TokenInfo {
+        address underlyingToken;
+        uint8 underlyingDecimals;
+        uint8 erc4626Decimals;
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                      STORAGE 
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @dev mapping of registered ERC4626 Tokens to their TokenInfo Struct
+    mapping(address => TokenInfo) private _tokenInfo;
+
+    address private constant _APXETH = 0x9Ba021B0a9b958B5E75cE9f6dff97C7eE52cb3E6;
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                     CONSTRUCTOR
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                      FUNCTIONS
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /**
+     * @notice Initializes the contract
+     * @param base The base oracle instance.
+     * @param owner Address of the owner of the contract.
+     */
+    function initialize(IBaseOracle base, address owner) external initializer {
+        __UsingBaseOracle_init(base, owner);
+    }
+
+    /// @inheritdoc IBaseOracle
+    function getPrice(address token) public view override returns (uint256) {
+        TokenInfo memory tokenInfo = _tokenInfo[token];
+        if (tokenInfo.underlyingToken == address(0)) {
+            revert Errors.ORACLE_NOT_SUPPORT(token);
+        }
+
+        uint256 fixedPointOne = 10 ** (18 + tokenInfo.erc4626Decimals - tokenInfo.underlyingDecimals);
+
+        return
+            (_base.getPrice(tokenInfo.underlyingToken) * _assetsPerShare(token, fixedPointOne)) /
+            (Constants.PRICE_PRECISION);
+    }
+
+    /**
+     * @notice Registers the token with the oracle
+     * @dev Stores persistent data of an ERC4626 token
+     * @dev An oracle cannot be used for a token unless it is registered
+     * @dev The tokens corresponding underlying token's price feed must be registered within
+     *      the base oracle to provide accurate price feeds.
+     * @param token Address of the ERC4626 Token
+     */
+    function registerToken(address token) external onlyOwner {
+        if (token == address(0)) revert Errors.ZERO_ADDRESS();
+
+        IERC4626 erc4626 = IERC4626(token);
+        address underlyingToken = erc4626.asset();
+
+        _tokenInfo[token] = TokenInfo({
+            underlyingToken: underlyingToken,
+            underlyingDecimals: IERC20Metadata(underlyingToken).decimals(),
+            erc4626Decimals: erc4626.decimals()
+        });
+    }
+
+    function _assetsPerShare(address token, uint256 fixedPointOne) internal view returns (uint256) {
+        if (token == _APXETH) {
+            return IApxEth(_APXETH).assetsPerShare();
+        }
+
+        return IERC4626(token).convertToAssets(fixedPointOne);
+    }
+}

--- a/contracts/oracle/ERC4626Oracle.sol
+++ b/contracts/oracle/ERC4626Oracle.sol
@@ -50,6 +50,7 @@ contract ERC4626Oracle is IBaseOracle, UsingBaseOracle {
     /// @dev mapping of registered ERC4626 Tokens to their TokenInfo Struct
     mapping(address => TokenInfo) private _tokenInfo;
 
+    /// @dev Address of the APXETH token
     address private constant _APXETH = 0x9Ba021B0a9b958B5E75cE9f6dff97C7eE52cb3E6;
 
     /*//////////////////////////////////////////////////////////////////////////
@@ -80,7 +81,6 @@ contract ERC4626Oracle is IBaseOracle, UsingBaseOracle {
         if (tokenInfo.underlyingToken == address(0)) {
             revert Errors.ORACLE_NOT_SUPPORT(token);
         }
-
         uint256 fixedPointOne = 10 ** (18 + tokenInfo.erc4626Decimals - tokenInfo.underlyingDecimals);
 
         return
@@ -109,6 +109,12 @@ contract ERC4626Oracle is IBaseOracle, UsingBaseOracle {
         });
     }
 
+    /**
+     *
+     * @param token The token address of the ERC4626 vault
+     * @param fixedPointOne Fixed point one representing 1 share of the ERC4626 vault
+     * @return The number of underlying assets per 1 share of the ERC4626 vault
+     */
     function _assetsPerShare(address token, uint256 fixedPointOne) internal view returns (uint256) {
         if (token == _APXETH) {
             return IApxEth(_APXETH).assetsPerShare();

--- a/test/oracle/erc4626-oracle.test.ts
+++ b/test/oracle/erc4626-oracle.test.ts
@@ -1,0 +1,90 @@
+import chai, { assert, expect } from 'chai';
+import { ethers, upgrades } from 'hardhat';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import { ADDRESS, CONTRACT_NAMES } from '../../constant';
+import { CoreOracle, ChainlinkAdapterOracle, ERC4626Oracle } from '../../typechain-types';
+
+import { near } from '../assertions/near';
+import { roughlyNear } from '../assertions/roughlyNear';
+import { fork } from '../helpers';
+
+chai.use(near);
+chai.use(roughlyNear);
+
+/* eslint-disable @typescript-eslint/no-unused-vars */
+describe('ERC4626 Oracle', () => {
+  let admin: SignerWithAddress;
+  let alice: SignerWithAddress;
+
+  let erc4626Oracle: ERC4626Oracle;
+  let coreOracle: CoreOracle;
+  let chainlinkOracle: ChainlinkAdapterOracle;
+
+  before(async () => {
+    [admin, alice] = await ethers.getSigners();
+    await fork(1, 19272826);
+
+    const CoreOracle = await ethers.getContractFactory(CONTRACT_NAMES.CoreOracle);
+    coreOracle = <CoreOracle>await upgrades.deployProxy(CoreOracle, [admin.address], { unsafeAllow: ['delegatecall'] });
+
+    const ChainlinkAdapterOracle = await ethers.getContractFactory(CONTRACT_NAMES.ChainlinkAdapterOracle);
+    chainlinkOracle = <ChainlinkAdapterOracle>await upgrades.deployProxy(ChainlinkAdapterOracle, [admin.address], {
+      unsafeAllow: ['delegatecall'],
+    });
+    await chainlinkOracle.deployed();
+
+    const ERC4626Oracle = await ethers.getContractFactory(CONTRACT_NAMES.ERC4626Oracle);
+    erc4626Oracle = <ERC4626Oracle>await upgrades.deployProxy(ERC4626Oracle, [coreOracle.address, admin.address], {
+      unsafeAllow: ['delegatecall'],
+    });
+    await erc4626Oracle.deployed();
+  });
+
+  describe('Owner', () => {
+    it('should be able to register tokens', async () => {
+      await expect(erc4626Oracle.connect(alice).registerToken(ADDRESS.apxETH)).to.be.revertedWith(
+        'Ownable: caller is not the owner'
+      );
+
+      await erc4626Oracle.registerToken(ADDRESS.apxETH);
+    });
+  });
+
+  describe('Token Pricing', () => {
+    it('should return correct price of apxETH', async () => {
+      const threeThousand = ethers.utils.parseEther('3000');
+      const thirtyTwoHundred = ethers.utils.parseEther('3300');
+
+      await chainlinkOracle.setPriceFeeds([ADDRESS.pxETH], ['0x19219BC90F48DeE4d5cF202E09c438FAacFd8Bea']);
+      await chainlinkOracle.setPriceFeeds([ADDRESS.CHAINLINK_ETH], ['0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419']);
+      await chainlinkOracle.setTimeGap([ADDRESS.pxETH], [40000]);
+      await chainlinkOracle.setTimeGap([ADDRESS.CHAINLINK_ETH], [40000]);
+      await chainlinkOracle.setEthDenominatedToken(ADDRESS.pxETH, true);
+
+      await coreOracle.setRoutes([ADDRESS.pxETH], [chainlinkOracle.address]);
+
+      await erc4626Oracle.registerToken(ADDRESS.apxETH);
+      const price = await erc4626Oracle.getPrice(ADDRESS.apxETH);
+
+      assert(price > threeThousand, 'Price is greater than 3000');
+      assert(price < thirtyTwoHundred, 'Price is less than 3200');
+    });
+
+    it('should return correct price of sDAI', async () => {
+      const pointNine = ethers.utils.parseEther('0.9');
+      const onePointOne = ethers.utils.parseEther('1.1');
+
+      await chainlinkOracle.setPriceFeeds([ADDRESS.DAI], ['0xAed0c38402a5d19df6E4c03F4E2DceD6e29c1ee9']);
+      await chainlinkOracle.setTimeGap([ADDRESS.DAI], [40000]);
+
+      await coreOracle.setRoutes([ADDRESS.DAI], [chainlinkOracle.address]);
+
+      const sDAI = '0x83F20F44975D03b1b09e64809B757c47f942BEeA';
+      await erc4626Oracle.registerToken(sDAI);
+      const price = await erc4626Oracle.getPrice(sDAI);
+
+      assert(price.gt(pointNine), 'Price is greater than 0.9');
+      assert(price.lt(onePointOne), 'Price is less than 1.1');
+    });
+  });
+});


### PR DESCRIPTION
# Description

This PR adds support for `ERC4626` tokens on Blueberry. This is a generalized approach that supports any standard `ERC4626` implementation. `apxETH` by Redacted Cartel will soon be available for Short/Long trading on Blueberry. While this token is a `ERC4626` token there it uses a unique pricing method that is not standard. To support this we added a calculation exception specifically for `apxETH`.  

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [x] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests are included for all code paths
- [x] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->