### PR TITLE
ParaSwap Lib Update

### DIFF
--- a/contracts/libraries/Paraswap/PSwapLib.sol
+++ b/contracts/libraries/Paraswap/PSwapLib.sol
@@ -32,13 +32,6 @@ library PSwapLib {
         (success, returndata) = augustusSwapper.call(data);
 
         UniversalERC20.universalApprove(IERC20(fromToken), tokenTransferProxy, 0);
-
-        if (returndata.length > 0) {
-            assembly {
-                let returndata_size := mload(returndata)
-                revert(add(32, returndata), returndata_size)
-            }
-        }
     }
 
     function megaSwap(


### PR DESCRIPTION
# Description

This PR removes the revert statement that gets called if the `AugustusSwapper` from Paraswap returns data after a swap. This is unnecessary due to checking `success` and actually bricks certain swaps from occurring if they are routed through a few minority of routes. 

## Type of change

- [x] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests are included for all code paths
- [x] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->