### PR TITLE
Optimize fuzz runs with bound instead of vm.assume

### DIFF
--- a/test/foundry/fork/spell/BankConvexSpell.t.sol
+++ b/test/foundry/fork/spell/BankConvexSpell.t.sol
@@ -84,14 +84,10 @@ contract BankConvexSpell is SpellBaseTest {
         uint256 borrowAmount,
         uint256 slippagePercent
     ) external {
-        if (collateralAmount > type(uint128).max || borrowAmount > type(uint96).max) return;
-        vm.assume(collateralAmount > 0);
-        vm.assume(collateralAmount < type(uint128).max);
-        vm.assume(slippagePercent >= 10); // slippage >= 0.1%
-        vm.assume(slippagePercent <= 500); // slippage <= 5%
+        collateralAmount = bound(collateralAmount, 1, type(uint128).max - 1);
+        borrowAmount = bound(borrowAmount, 1, type(uint96).max - 1);
+        slippagePercent = bound(slippagePercent, 10 /* 0.1% */, 500 /* 5% */);
 
-        vm.assume(borrowAmount > 0);
-        vm.assume(borrowAmount < type(uint96).max);
         uint256 borrowValue = coreOracle.getTokenValue(address(WETH), borrowAmount);
         uint256 icollValue = coreOracle.getTokenValue(USDC, collateralAmount);
         uint256 maxLTV = convexSpell.getMaxLTV(0, USDC);


### PR DESCRIPTION
# Description

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->

Optimize fuzz runs with `bound` instead of `vm.assume` when appropriate
Reference: https://book.getfoundry.sh/cheatcodes/assume?highlight=assume#assume

## Type of change

- [x] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests are included for all code paths
- [x] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->