### PR TITLE
minPosition checks shifted to minIsolatedCollateral

### DIFF
--- a/contracts/interfaces/spell/IAuraSpell.sol
+++ b/contracts/interfaces/spell/IAuraSpell.sol
@@ -13,10 +13,10 @@ interface IAuraSpell is IBasicSpell {
     /**
      * @notice Allows the owner to add a new strategy.
      * @param bpt Address of the Balancer Pool Token.
-     * @param minPosSize, USD price of minimum position size for given strategy, based 1e18
+     * @param minCollSize, USD price of minimum position size for given strategy, based 1e18
      * @param maxPosSize, USD price of maximum position size for given strategy, based 1e18
      */
-    function addStrategy(address bpt, uint256 minPosSize, uint256 maxPosSize) external;
+    function addStrategy(address bpt, uint256 minCollSize, uint256 maxPosSize) external;
 
     /**
      * @notice Adds liquidity to a Balancer pool and stakes the resultant tokens in Aura.

--- a/contracts/interfaces/spell/IAuraSpell.sol
+++ b/contracts/interfaces/spell/IAuraSpell.sol
@@ -13,7 +13,7 @@ interface IAuraSpell is IBasicSpell {
     /**
      * @notice Allows the owner to add a new strategy.
      * @param bpt Address of the Balancer Pool Token.
-     * @param minCollSize, USD price of minimum position size for given strategy, based 1e18
+     * @param minCollSize, USD price of minimum isolated collateral for given strategy, based 1e18
      * @param maxPosSize, USD price of maximum position size for given strategy, based 1e18
      */
     function addStrategy(address bpt, uint256 minCollSize, uint256 maxPosSize) external;

--- a/contracts/interfaces/spell/IBasicSpell.sol
+++ b/contracts/interfaces/spell/IBasicSpell.sol
@@ -10,12 +10,12 @@ interface IBasicSpell {
     /**
      * @dev Defines strategies for Blueberry Protocol.
      * @param vault Address of the vault where assets are held.
-     * @param minPositionSize Minimum size of the position in USD.
+     * @param minIsolatedCollateral Minimum size of isolated collateral in USD.
      * @param maxPositionSize Maximum size of the position in USD.
      */
     struct Strategy {
         address vault;
-        uint256 minPositionSize;
+        uint256 minIsolatedCollateral;
         uint256 maxPositionSize;
     }
 
@@ -65,18 +65,18 @@ interface IBasicSpell {
      * @notice This event is emitted when a new strategy is added.
      * @param strategyId Unique identifier for the strategy.
      * @param vault Address of the vault where assets are held.
-     * @param minPosSize Minimum size of the position in USD.
+     * @param minCollSize Minimum size of the isolated collateral in USD.
      * @param maxPosSize Maximum size of the position in USD.
      */
-    event StrategyAdded(uint256 strategyId, address vault, uint256 minPosSize, uint256 maxPosSize);
+    event StrategyAdded(uint256 strategyId, address vault, uint256 minCollSize, uint256 maxPosSize);
 
     /**
      * @notice This event is emitted when a strategy's min/max position size is updated.
      * @param strategyId Unique identifier for the strategy.
-     * @param minPosSize Minimum size of the position in USD.
+     * @param minCollSize Minimum size of the isolated collateral in USD.
      * @param maxPosSize Maximum size of the position in USD.
      */
-    event StrategyPosSizeUpdated(uint256 strategyId, uint256 minPosSize, uint256 maxPosSize);
+    event StrategyPosSizeUpdated(uint256 strategyId, uint256 minCollSize, uint256 maxPosSize);
 
     /**
      * @notice This event is emitted when a strategy's collateral max LTV is updated.
@@ -90,10 +90,10 @@ interface IBasicSpell {
      * @notice Update the position sizes for a specific strategy.
      * @dev This function validates the inputs, updates the strategy's position sizes, and emits an event.
      * @param strategyId ID of the strategy to be updated.
-     * @param minPosSize New minimum position size for the strategy.
+     * @param minCollSize New minimum size of the isolated collateral for the strategy.
      * @param maxPosSize New maximum position size for the strategy.
      */
-    function setPosSize(uint256 strategyId, uint256 minPosSize, uint256 maxPosSize) external;
+    function setPosSize(uint256 strategyId, uint256 minCollSize, uint256 maxPosSize) external;
 
     /**
      * @notice Set maximum Loan-To-Value (LTV) ratios for collaterals in a given strategy.

--- a/contracts/interfaces/spell/IConvexSpell.sol
+++ b/contracts/interfaces/spell/IConvexSpell.sol
@@ -33,10 +33,10 @@ interface IConvexSpell is IBasicSpell {
     /**
      * @notice Adds a new strategy to the spell.
      * @param crvLp Address of the Curve LP token for the strategy.
-     * @param minPosSize Minimum position size in USD for the strategy (with 1e18 precision).
+     * @param minCollSize Minimum position size in USD for the strategy (with 1e18 precision).
      * @param maxPosSize Maximum position size in USD for the strategy (with 1e18 precision).
      */
-    function addStrategy(address crvLp, uint256 minPosSize, uint256 maxPosSize) external;
+    function addStrategy(address crvLp, uint256 minCollSize, uint256 maxPosSize) external;
 
     /// @notice Returns the address of the Cvx oracle.
     function getCrvOracle() external view returns (ICurveOracle);

--- a/contracts/interfaces/spell/IConvexSpell.sol
+++ b/contracts/interfaces/spell/IConvexSpell.sol
@@ -33,7 +33,7 @@ interface IConvexSpell is IBasicSpell {
     /**
      * @notice Adds a new strategy to the spell.
      * @param crvLp Address of the Curve LP token for the strategy.
-     * @param minCollSize Minimum position size in USD for the strategy (with 1e18 precision).
+     * @param minCollSize Minimum isolated collateral in USD for the strategy (with 1e18 precision).
      * @param maxPosSize Maximum position size in USD for the strategy (with 1e18 precision).
      */
     function addStrategy(address crvLp, uint256 minCollSize, uint256 maxPosSize) external;

--- a/contracts/interfaces/spell/IIchiSpell.sol
+++ b/contracts/interfaces/spell/IIchiSpell.sol
@@ -14,7 +14,7 @@ interface IIchiSpell is IBasicSpell {
     /**
      * @notice Adds a strategy to the contract.
      * @param vault Address of the vault linked to the strategy.
-     * @param minCollSize Minimum position size in USD, normalized to 1e18.
+     * @param minCollSize Minimum isolated collateral in USD, normalized to 1e18.
      * @param maxPosSize Maximum position size in USD, normalized to 1e18.
      */
     function addStrategy(address vault, uint256 minCollSize, uint256 maxPosSize) external;

--- a/contracts/interfaces/spell/IIchiSpell.sol
+++ b/contracts/interfaces/spell/IIchiSpell.sol
@@ -14,10 +14,10 @@ interface IIchiSpell is IBasicSpell {
     /**
      * @notice Adds a strategy to the contract.
      * @param vault Address of the vault linked to the strategy.
-     * @param minPosSize Minimum position size in USD, normalized to 1e18.
+     * @param minCollSize Minimum position size in USD, normalized to 1e18.
      * @param maxPosSize Maximum position size in USD, normalized to 1e18.
      */
-    function addStrategy(address vault, uint256 minPosSize, uint256 maxPosSize) external;
+    function addStrategy(address vault, uint256 minCollSize, uint256 maxPosSize) external;
 
     /**
      * @notice Deposits assets into an IchiVault.

--- a/contracts/interfaces/spell/IShortLongSpell.sol
+++ b/contracts/interfaces/spell/IShortLongSpell.sol
@@ -12,7 +12,7 @@ interface IShortLongSpell is IBasicSpell {
     /**
      * @notice Add strategy to the spell
      * @param swapToken Address of token for given strategy
-     * @param minCollSize USD price of minimum position size for given strategy, based 1e18
+     * @param minCollSize USD price of minimum isolated collateral for given strategy, based 1e18
      * @param maxPosSize USD price of maximum position size for given strategy, based 1e18
      */
     function addStrategy(address swapToken, uint256 minCollSize, uint256 maxPosSize) external;

--- a/contracts/interfaces/spell/IShortLongSpell.sol
+++ b/contracts/interfaces/spell/IShortLongSpell.sol
@@ -12,10 +12,10 @@ interface IShortLongSpell is IBasicSpell {
     /**
      * @notice Add strategy to the spell
      * @param swapToken Address of token for given strategy
-     * @param minPosSize USD price of minimum position size for given strategy, based 1e18
+     * @param minCollSize USD price of minimum position size for given strategy, based 1e18
      * @param maxPosSize USD price of maximum position size for given strategy, based 1e18
      */
-    function addStrategy(address swapToken, uint256 minPosSize, uint256 maxPosSize) external;
+    function addStrategy(address swapToken, uint256 minCollSize, uint256 maxPosSize) external;
 
     /**
      * @notice Opens a position using provided parameters and swap data.

--- a/contracts/spell/AuraSpell.sol
+++ b/contracts/spell/AuraSpell.sol
@@ -86,8 +86,8 @@ contract AuraSpell is IAuraSpell, BasicSpell {
     }
 
     /// @inheritdoc IAuraSpell
-    function addStrategy(address bpt, uint256 minPosSize, uint256 maxPosSize) external onlyOwner {
-        _addStrategy(bpt, minPosSize, maxPosSize);
+    function addStrategy(address bpt, uint256 minCollSize, uint256 maxPosSize) external onlyOwner {
+        _addStrategy(bpt, minCollSize, maxPosSize);
     }
 
     /// @inheritdoc IAuraSpell

--- a/contracts/spell/BasicSpell.sol
+++ b/contracts/spell/BasicSpell.sol
@@ -140,7 +140,7 @@ abstract contract BasicSpell is IBasicSpell, ERC1155NaiveReceiver, Ownable2StepU
      * @dev Internal function that appends to the strategies array.
      * @dev Emit {StrategyAdded} event.
      * @param vault The address of the vault associated with this strategy.
-     * @param minCollSize The minimum isolated Collateral size (USD value) for this strategy. Value is based on 1e18.
+     * @param minCollSize The minimum isolated collateral size (USD value) for this strategy. Value is based on 1e18.
      * @param maxPosSize The maximum position size (USD value) for this strategy. Value is based on 1e18.
      */
     function _addStrategy(address vault, uint256 minCollSize, uint256 maxPosSize) internal {
@@ -309,7 +309,7 @@ abstract contract BasicSpell is IBasicSpell, ERC1155NaiveReceiver, Ownable2StepU
         // Get isolated collateral value
         uint256 isolatedCollateralValue = bank.getIsolatedCollateralValue(bank.POSITION_ID());
 
-        // Check if isolated Collateral size is within bounds
+        // Check if isolated collateral size is within bounds
         if (isolatedCollateralValue < strategy.minIsolatedCollateral) {
             revert Errors.BELOW_MIN_ISOLATED_COLLATERAL(strategyId);
         }

--- a/contracts/spell/BasicSpell.sol
+++ b/contracts/spell/BasicSpell.sol
@@ -27,7 +27,7 @@ import { IERC20Wrapper } from "../interfaces/IERC20Wrapper.sol";
 import { IWERC20 } from "../interfaces/IWERC20.sol";
 import { IWETH } from "../interfaces/IWETH.sol";
 import { IBasicSpell } from "../interfaces/spell/IBasicSpell.sol";
-import "hardhat/console.sol";
+
 /**
  * @title BasicSpell
  * @author BlueberryProtocol
@@ -308,7 +308,7 @@ abstract contract BasicSpell is IBasicSpell, ERC1155NaiveReceiver, Ownable2StepU
 
         // Get isolated collateral value
         uint256 isolatedCollateralValue = bank.getIsolatedCollateralValue(bank.POSITION_ID());
-        console.log("isolatedCollateralValue: %s", isolatedCollateralValue);
+
         // Check if isolated Collateral size is within bounds
         if (isolatedCollateralValue < strategy.minIsolatedCollateral) {
             revert Errors.BELOW_MIN_ISOLATED_COLLATERAL(strategyId);

--- a/contracts/spell/ConvexSpell.sol
+++ b/contracts/spell/ConvexSpell.sol
@@ -108,8 +108,8 @@ contract ConvexSpell is IConvexSpell, BasicSpell {
     }
 
     /// @inheritdoc IConvexSpell
-    function addStrategy(address crvLp, uint256 minPosSize, uint256 maxPosSize) external onlyOwner {
-        _addStrategy(crvLp, minPosSize, maxPosSize);
+    function addStrategy(address crvLp, uint256 minCollSize, uint256 maxPosSize) external onlyOwner {
+        _addStrategy(crvLp, minCollSize, maxPosSize);
     }
 
     /// @inheritdoc IConvexSpell

--- a/contracts/spell/ConvexSpellV2.sol
+++ b/contracts/spell/ConvexSpellV2.sol
@@ -109,8 +109,8 @@ contract ConvexSpellV2 is IConvexSpell, BasicSpell {
     }
 
     /// @inheritdoc IConvexSpell
-    function addStrategy(address crvLp, uint256 minPosSize, uint256 maxPosSize) external onlyOwner {
-        _addStrategy(crvLp, minPosSize, maxPosSize);
+    function addStrategy(address crvLp, uint256 minCollSize, uint256 maxPosSize) external onlyOwner {
+        _addStrategy(crvLp, minCollSize, maxPosSize);
     }
 
     /// @inheritdoc IConvexSpell

--- a/contracts/spell/IchiSpell.sol
+++ b/contracts/spell/IchiSpell.sol
@@ -94,8 +94,8 @@ contract IchiSpell is IIchiSpell, BasicSpell {
     }
 
     /// @inheritdoc IIchiSpell
-    function addStrategy(address vault, uint256 minPosSize, uint256 maxPosSize) external onlyOwner {
-        _addStrategy(vault, minPosSize, maxPosSize);
+    function addStrategy(address vault, uint256 minCollSize, uint256 maxPosSize) external onlyOwner {
+        _addStrategy(vault, minCollSize, maxPosSize);
     }
 
     /// @inheritdoc IIchiSpell

--- a/contracts/spell/ShortLongSpell.sol
+++ b/contracts/spell/ShortLongSpell.sol
@@ -124,8 +124,8 @@ contract ShortLongSpell is IShortLongSpell, BasicSpell {
     }
 
     /// @inheritdoc IShortLongSpell
-    function addStrategy(address swapToken, uint256 minPosSize, uint256 maxPosSize) external onlyOwner {
-        _addStrategy(swapToken, minPosSize, maxPosSize);
+    function addStrategy(address swapToken, uint256 minCollSize, uint256 maxPosSize) external onlyOwner {
+        _addStrategy(swapToken, minCollSize, maxPosSize);
     }
 
     /**

--- a/contracts/utils/BlueberryErrors.sol
+++ b/contracts/utils/BlueberryErrors.sol
@@ -127,8 +127,8 @@ error STRATEGY_NOT_EXIST(address spell, uint256 strategyId);
 /// @notice Thrown when the position size exceeds maximum limits.
 error EXCEED_MAX_POS_SIZE(uint256 strategyId);
 
-/// @notice Thrown when the position size is below minimum requirements.
-error EXCEED_MIN_POS_SIZE(uint256 strategyId);
+/// @notice Thrown when the user has not deposited enough isolated collateral for a strategy.
+error BELOW_MIN_ISOLATED_COLLATERAL(uint256 strategyId);
 
 /// @notice Thrown when the loan-to-value ratio exceeds allowed maximum.
 error EXCEED_MAX_LTV();

--- a/test/liquidator/AuraLiquidation.test.ts
+++ b/test/liquidator/AuraLiquidation.test.ts
@@ -46,7 +46,7 @@ describe('Aura Liquidator', () => {
     spell = protocol.auraSpell;
     mockOracle = protocol.mockOracle;
 
-    const depositAmount = utils.parseUnits('100', 18); // CRV => $100
+    const depositAmount = utils.parseUnits('110', 18); // CRV => $110
     const borrowAmount = utils.parseUnits('250', 6); // USDC
     const iface = new ethers.utils.Interface(SpellABI);
 

--- a/test/liquidator/ConvexLiquidation.test.ts
+++ b/test/liquidator/ConvexLiquidation.test.ts
@@ -51,7 +51,7 @@ describe('Convex Liquidator', () => {
     mockOracle = protocol.mockOracle;
     const iface = new ethers.utils.Interface(SpellABI);
 
-    const depositAmount = utils.parseUnits('100', 18); // CRV => $100
+    const depositAmount = utils.parseUnits('110', 18); // CRV => $100
     const borrowAmount = utils.parseUnits('250', 6); // USDC
     await usdc.approve(bank.address, ethers.constants.MaxUint256);
     await dai.approve(bank.address, ethers.constants.MaxUint256);

--- a/test/spell/ShortLongSpell.test.ts
+++ b/test/spell/ShortLongSpell.test.ts
@@ -198,7 +198,7 @@ describe('ShortLongSpell', () => {
       );
     });
 
-    it('should revert when minPosSize >= maxPosSize', async () => {
+    it('should revert when minCollSize >= maxPosSize', async () => {
       await expect(spell.connect(admin).addStrategy(weth.address, 10, 10)).to.be.revertedWithCustomError(
         spell,
         'INVALID_POS_SIZE'
@@ -210,7 +210,7 @@ describe('ShortLongSpell', () => {
 
       const strategy = await spell.getStrategy(0);
       expect(strategy.vault).to.eq(weth.address);
-      expect(strategy.minPositionSize).to.eq(1);
+      expect(strategy.minIsolatedCollateral).to.eq(1);
       expect(strategy.maxPositionSize).to.eq(10);
     });
 

--- a/test/spell/aura.spell.test.ts
+++ b/test/spell/aura.spell.test.ts
@@ -162,7 +162,7 @@ describe('Aura Spell', () => {
   });
 
   describe('Aura Pool Farming Position', () => {
-    const depositAmount = utils.parseUnits('100', 18); // CRV => $100
+    const depositAmount = utils.parseUnits('110', 18); // CRV => $110
     const borrowAmount = utils.parseUnits('250', 6); // USDC
     const iface = new ethers.utils.Interface(SpellABI);
 

--- a/test/spell/convex.spell.test.ts
+++ b/test/spell/convex.spell.test.ts
@@ -185,7 +185,7 @@ describe('Convex Spell', () => {
   });
 
   describe('Convex Pool Farming Position', () => {
-    const depositAmount = utils.parseUnits('100', 18); // CRV => $100
+    const depositAmount = utils.parseUnits('110', 18); // CRV => $110
     const borrowAmount = utils.parseUnits('250', 6); // USDC
     const iface = new ethers.utils.Interface(SpellABI);
 
@@ -639,7 +639,7 @@ describe('Convex Spell', () => {
               0,
             ])
           )
-        ).to.be.revertedWithCustomError(spell, 'EXCEED_MIN_POS_SIZE');
+        ).to.be.revertedWithCustomError(spell, 'BELOW_MIN_ISOLATED_COLLATERAL');
       });
     });
   });

--- a/test/spell/ichi.spell.test.ts
+++ b/test/spell/ichi.spell.test.ts
@@ -190,11 +190,10 @@ describe('ICHI Angel Vaults Spell', () => {
         )
       ).to.be.revertedWithCustomError(spell, 'EXCEED_MAX_LTV');
     });
-    it('should revert when exceeds min pos size', async () => {
-      // Max position is set as 2,000
+    it('should revert when below min isolated collateral size', async () => {
+      // Min isolated collateral size is set to 10 USD
       await ichi.approve(bank.address, ethers.constants.MaxUint256);
 
-      // Call openPosition with 0.1 is fail because is below min position size
       await expect(
         bank.execute(
           0,
@@ -204,14 +203,14 @@ describe('ICHI Angel Vaults Spell', () => {
               strategyId: 0,
               collToken: ICHI,
               borrowToken: USDC,
-              collAmount: depositAmount.mul(40),
+              collAmount: depositAmount.div(10),
               borrowAmount: utils.parseUnits('0.1', 6),
               farmingPoolId: 0,
             },
           ])
         )
       )
-        .to.be.revertedWithCustomError(spell, 'EXCEED_MIN_POS_SIZE')
+        .to.be.revertedWithCustomError(spell, 'BELOW_MIN_ISOLATED_COLLATERAL')
         .withArgs(0);
     });
     it('should revert when exceeds max pos size', async () => {
@@ -1160,7 +1159,7 @@ describe('ICHI Angel Vaults Spell', () => {
 
   describe('Owner Functions', () => {
     let spell: IchiSpell;
-    const minPosSize = utils.parseEther('100');
+    const minCollSize = utils.parseEther('100');
     const maxPosSize = utils.parseEther('200000');
 
     beforeEach(async () => {
@@ -1186,15 +1185,15 @@ describe('ICHI Angel Vaults Spell', () => {
 
     describe('Add Strategy', () => {
       it('only owner should be able to add new strategies to the spell', async () => {
-        await expect(spell.connect(alice).addStrategy(ichiVault.address, minPosSize, maxPosSize)).to.be.revertedWith(
+        await expect(spell.connect(alice).addStrategy(ichiVault.address, minCollSize, maxPosSize)).to.be.revertedWith(
           'Ownable: caller is not the owner'
         );
       });
       it('should revert when vault address or maxPosSize is zero', async () => {
         await expect(
-          spell.addStrategy(ethers.constants.AddressZero, minPosSize, maxPosSize)
+          spell.addStrategy(ethers.constants.AddressZero, minCollSize, maxPosSize)
         ).to.be.revertedWithCustomError(spell, 'ZERO_ADDRESS');
-        await expect(spell.addStrategy(ichiVault.address, minPosSize, 0)).to.be.revertedWithCustomError(
+        await expect(spell.addStrategy(ichiVault.address, minCollSize, 0)).to.be.revertedWithCustomError(
           spell,
           'ZERO_AMOUNT'
         );
@@ -1204,31 +1203,31 @@ describe('ICHI Angel Vaults Spell', () => {
         );
       });
       it('owner should be able to add strategy', async () => {
-        await expect(spell.addStrategy(ichiVault.address, minPosSize, maxPosSize))
+        await expect(spell.addStrategy(ichiVault.address, minCollSize, maxPosSize))
           .to.be.emit(spell, 'StrategyAdded')
-          .withArgs(0, ichiVault.address, minPosSize, maxPosSize);
+          .withArgs(0, ichiVault.address, minCollSize, maxPosSize);
       });
       it('owner should be able to update max pos size', async () => {
-        await spell.addStrategy(ichiVault.address, minPosSize, maxPosSize);
-        await expect(spell.connect(alice).setPosSize(0, minPosSize, maxPosSize)).to.be.revertedWith(
+        await spell.addStrategy(ichiVault.address, minCollSize, maxPosSize);
+        await expect(spell.connect(alice).setPosSize(0, minCollSize, maxPosSize)).to.be.revertedWith(
           'Ownable: caller is not the owner'
         );
-        await expect(spell.setPosSize(10, minPosSize, maxPosSize))
+        await expect(spell.setPosSize(10, minCollSize, maxPosSize))
           .to.be.revertedWithCustomError(spell, 'STRATEGY_NOT_EXIST')
           .withArgs(spell.address, 10);
-        await expect(spell.setPosSize(0, minPosSize, 0)).to.be.revertedWithCustomError(spell, 'ZERO_AMOUNT');
+        await expect(spell.setPosSize(0, minCollSize, 0)).to.be.revertedWithCustomError(spell, 'ZERO_AMOUNT');
         await expect(spell.setPosSize(0, maxPosSize, maxPosSize)).to.be.revertedWithCustomError(
           spell,
           'INVALID_POS_SIZE'
         );
 
-        await expect(spell.setPosSize(0, minPosSize, maxPosSize)).to.be.emit(spell, 'StrategyPosSizeUpdated');
+        await expect(spell.setPosSize(0, minCollSize, maxPosSize)).to.be.emit(spell, 'StrategyPosSizeUpdated');
       });
     });
 
     describe('Add Collaterals', () => {
       beforeEach(async () => {
-        await spell.addStrategy(ichiVault.address, minPosSize, maxPosSize);
+        await spell.addStrategy(ichiVault.address, minCollSize, maxPosSize);
       });
       it('only owner should be able to add collaterals', async () => {
         await expect(spell.connect(alice).setCollateralsMaxLTVs(0, [USDC, ICHI], [30000, 30000])).to.be.revertedWith(


### PR DESCRIPTION
# Description

Currently within Blueberry all leveraged positions have to pass a verification check that mandates the position value be within a certain bounds. This value is set within the `addStrategy` function. These checks are perfectly acceptable, but operationally we would prefer to check the isolated collateral value for setting a minimum requirement to enter a position instead of the overall position value. 

Changes Made:
- `minPositionSize` -> `minIsolatedCollateral` 
- Checks within the `BasicSpell` switched from validating that a position is above the minimum position value to validating that the isolated collateral's value is above the strategies `minIsolatedCollateral`.
- Error message `EXCEED_MIN_POS_SIZE` -> `BELOW_MIN_ISOLATED_COLLATERAL`
- Tests adapted to this change.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [x] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests are included for all code paths
- [x] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->