### PR TITLE
Remove redundant withdraw fee in the Bank

### DIFF
--- a/contracts/BlueberryBank.sol
+++ b/contracts/BlueberryBank.sol
@@ -293,7 +293,6 @@ contract BlueberryBank is IBank, Ownable2StepUpgradeable, ERC1155NaiveReceiver {
 
         pos.underlyingVaultShare -= shareAmount;
         IERC20(token).universalApprove(address(feeManager), wAmount);
-        wAmount = feeManager.doCutWithdrawFee(token, wAmount);
         IERC20Upgradeable(token).safeTransfer(msg.sender, wAmount);
         emit WithdrawLend(_POSITION_ID, msg.sender, token, wAmount);
     }


### PR DESCRIPTION
# Description

Currently during `withdrawLend` in the `BlueberryBank` two fee's are taken:

1. Within  `SoftVault#withdraw`/`HardVault#withdraw`
2. An additional fee at the end of the transaction on line 296, `feeManager.doCutWithdrawFee(token, wAmount)`

Since fees are already taken properly in the initial `withdraw` from the `SoftVault` or `HardVault`, we are over-charging users on withdraws which will have negative impacts on user's PnL, especially when leverage is involved. 

To fix this issue we simply just need to remove line 296 where the second fee is taken.

## Type of change

- [x] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests are included for all code paths
- [x] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->