### PR TITLE
Update MIN_TIME_GAP constant to 3 minutes

### DIFF
--- a/contracts/utils/BlueberryConst.sol
+++ b/contracts/utils/BlueberryConst.sol
@@ -28,7 +28,7 @@ uint256 constant PRICE_PRECISION = 1e18;
 uint256 constant MAX_PRICE_DEVIATION = 1000; // represent 10%
 
 /// @dev Minimum time interval for specific time-dependent operations.
-uint32 constant MIN_TIME_GAP = 1 hours;
+uint32 constant MIN_TIME_GAP = 3 minutes;
 
 /// @dev Maximum time interval for specific time-dependent operations.
 uint32 constant MAX_TIME_GAP = 2 days;


### PR DESCRIPTION
# Description

Currently `MIN_TIME_GAP` was set to `1 hours` but this causes the `getPrice` call on certain Ichi Vaults to revert due to their `twapPeriod` being 5 minutes. In order to support bluechip tokens such as `USDC`, `WETH`, and `WBTC` and to decrease slippage for users it is important to decrease this value to `3 minutes`.

## Type of change

- [x] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests are included for all code paths
- [x] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->