### PR TITLE
Round down for share amount in borrow

### DIFF
--- a/contracts/BlueberryBank.sol
+++ b/contracts/BlueberryBank.sol
@@ -315,7 +315,7 @@ contract BlueberryBank is IBank, Ownable2StepUpgradeable, ERC1155NaiveReceiver {
 
         uint256 totalShare = bank.totalShare;
         uint256 totalDebt = _borrowBalanceStored(token);
-        uint256 share = totalShare == 0 ? amount : (amount * totalShare).divCeil(totalDebt);
+        uint256 share = totalShare == 0 ? amount : (amount * totalShare) / totalDebt;
         if (share == 0) revert Errors.BORROW_ZERO_SHARE(amount);
         bank.totalShare += share;
         pos.debtShare += share;


### PR DESCRIPTION
# Description

Within `borrow` of `BlueberryBank` there is incorrect rounding that rounds the end `share` value up. Rounding should always favor the protocol and failure to do so has been the source for countless protocol exploits. This PR addresses this and removes `divCeil` from the calculation of the `share` value and instead replaces the calculation with native Solidity division, which rounds downs.

## Type of change

- [x] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests are included for all code paths
- [x] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->