### PR TITLE
wAuraBooster Update

### DIFF
--- a/contracts/interfaces/IWAuraBooster.sol
+++ b/contracts/interfaces/IWAuraBooster.sol
@@ -34,17 +34,17 @@ interface IWAuraBooster is IERC1155Upgradeable, IERC20Wrapper {
     event Burned(uint256 indexed id, uint256 indexed pid, uint256 amount);
 
     /**
-     * @notice Struct for storing information regarding an Aura Pools Stash Token.
+     * @notice Struct for storing information regarding an Aura Pools StashAura Token.
      * @param stashToken The address of the stash token.
      * @param rewarder The address of the rewarder contract.
      * @param lastStashRewardPerToken The last reward per token value for the stash token.
      * @param stashAuraReceived The amount of AURA received by the stash token.
      */
-    struct StashTokenInfo {
-        address stashToken;
+    struct StashAuraInfo {
+        address stashAuraToken;
         address rewarder;
         uint256 lastStashRewardPerToken;
-        uint256 stashAuraReceived;
+        uint256 stashAuraAuraReceived;
     }
 
     /**
@@ -140,7 +140,7 @@ interface IWAuraBooster is IERC1155Upgradeable, IERC20Wrapper {
      * @return token The reward token's address for the specific pool.
      * @return gauge The gauge contract's address for the specific pool.
      * @return crvRewards The curve rewards contract's address associated with the specific pool.
-     * @return stash The stash contract's address associated with the specific pool.
+     * @return stash The stashAura contract's address associated with the specific pool.
      * @return shutdown A boolean indicating if the pool is in shutdown mode.
      */
     function getPoolInfoFromPoolId(

--- a/contracts/interfaces/aura/IStashToken.sol
+++ b/contracts/interfaces/aura/IStashToken.sol
@@ -2,7 +2,7 @@
 
 pragma solidity 0.8.22;
 
-interface IAuraStashToken {
+interface IStashToken {
     function baseToken() external view returns (address);
 
     function rewardPool() external view returns (address);

--- a/contracts/mock/MockStashToken.sol
+++ b/contracts/mock/MockStashToken.sol
@@ -6,9 +6,9 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/utils/math/SafeMath.sol";
 import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
-import "../interfaces/aura/IAuraStashToken.sol";
+import "../interfaces/aura/IStashToken.sol";
 
-contract MockStashToken is IAuraStashToken {
+contract MockStashToken is IStashToken {
     using SafeERC20 for IERC20;
     using SafeMath for uint256;
 
@@ -44,8 +44,11 @@ contract MockStashToken is IAuraStashToken {
         IERC20(baseToken).safeTransferFrom(msg.sender, address(this), _amount);
     }
 
+    function rewardToken() external view returns (address) {
+        return baseToken;
+    }
+
     function transfer(address _to, uint256 _amount) public returns (bool) {
-        require(msg.sender == rewardPool, "!rewardPool");
         require(_totalSupply >= _amount, "amount>totalSupply");
 
         _totalSupply = _totalSupply.sub(_amount);

--- a/contracts/wrapper/WAuraBooster.sol
+++ b/contracts/wrapper/WAuraBooster.sol
@@ -32,7 +32,6 @@ import { IPoolEscrow } from "./escrow/interfaces/IPoolEscrow.sol";
 import { IPoolEscrowFactory } from "./escrow/interfaces/IPoolEscrowFactory.sol";
 import { IRewarder } from "../interfaces/convex/IRewarder.sol";
 import { IStashToken } from "../interfaces/aura/IStashToken.sol";
-import "hardhat/console.sol";
 
 /**
  * @title WAuraBooster
@@ -255,9 +254,9 @@ contract WAuraBooster is IWAuraBooster, ERC1155Upgradeable, ReentrancyGuardUpgra
                 stashAuraFound = true;
                 continue;
             }
-            console.log("rewardToken: %s", rewardToken);
+
             rewardToken = IStashToken(rewardToken).baseToken();
-            console.log("rewardToken: %s", rewardToken);
+
             uint256 tokenRewardPerShare = _initialTokenPerShare[tokenId][rewarder];
             tokens[index + 2] = rewardToken;
 

--- a/contracts/wrapper/WAuraBooster.sol
+++ b/contracts/wrapper/WAuraBooster.sol
@@ -427,7 +427,7 @@ contract WAuraBooster is IWAuraBooster, ERC1155Upgradeable, ReentrancyGuardUpgra
         address stashAuraToken = stashAuraInfo.stashAuraToken;
 
         // _auraRewarder rewards users in AURA
-        (, , , address _auraRewarder, address stash, ) = getPoolInfoFromPoolId(pid);
+        (, , , address _auraRewarder, address stashAura, ) = getPoolInfoFromPoolId(pid);
         uint256 lastBalPerToken = IRewarder(_auraRewarder).rewardPerToken();
 
         // If the token is not minted yet the tokenId will be 0
@@ -437,7 +437,7 @@ contract WAuraBooster is IWAuraBooster, ERC1155Upgradeable, ReentrancyGuardUpgra
         }
 
         if (stashAuraToken == address(0)) {
-            _setAuraStashToken(stashAuraInfo, _auraRewarder, stash);
+            _setAuraStashToken(stashAuraInfo, _auraRewarder, stashAura);
         }
 
         uint256 currentDeposits = IRewarder(_auraRewarder).balanceOf(escrow);

--- a/test/spell/aura.spell.test.ts
+++ b/test/spell/aura.spell.test.ts
@@ -49,7 +49,6 @@ describe('Aura Spell', () => {
   let bank: BlueberryBank;
   let protocol: AuraProtocol;
   let auraBooster: IAuraBooster;
-  let auraRewarder: IRewarder;
   let config: ProtocolConfig;
 
   before(async () => {
@@ -514,7 +513,6 @@ describe('Aura Spell', () => {
       const swapData = (await getParaswapCalldata(CRV, USDC, amountToSwap, spell.address, 100)).data;
 
       const beforeTreasuryBalance = await crv.balanceOf(treasury.address);
-      const beforeUSDCBalance = await usdc.balanceOf(admin.address);
       const beforeCrvBalance = await crv.balanceOf(admin.address);
 
       await bank.execute(
@@ -536,7 +534,6 @@ describe('Aura Spell', () => {
           swapDatas.map((item) => item.data),
         ])
       );
-      const afterUSDCBalance = await usdc.balanceOf(admin.address);
       const afterCrvBalance = await crv.balanceOf(admin.address);
 
       const depositFee = depositAmount.mul(50).div(10000);

--- a/test/spell/aura.spell.test.ts
+++ b/test/spell/aura.spell.test.ts
@@ -349,11 +349,6 @@ describe('Aura Spell', () => {
       pv = await bank.callStatic.getPositionValue(1);
       ov = await bank.callStatic.getDebtValue(1);
       cv = await bank.callStatic.getIsolatedCollateralValue(1);
-      console.log('=======');
-      console.log('PV:', utils.formatUnits(pv));
-      console.log('OV:', utils.formatUnits(ov));
-      console.log('CV:', utils.formatUnits(cv));
-      console.log('Position Risk', utils.formatUnits(risk, 2), '%');
     });
     // TODO: Find another USDC curve pool
     // it("should revert increasing existing position when diff pos param given", async () => {
@@ -437,11 +432,6 @@ describe('Aura Spell', () => {
       const positionId = (await bank.getNextPositionId()).sub(1);
       const position = await bank.getPositionInfo(positionId);
 
-      const debtAmount = await bank.callStatic.currentPositionDebt(positionId);
-
-      const totalEarned = await auraRewarder.earned(waura.address);
-      console.log('Wrapper Total Earned:', utils.formatUnits(totalEarned));
-
       const pendingRewardsInfo = await waura.callStatic.pendingRewards(position.collId, position.collateralSize);
 
       const rewardFeeRatio = await config.getRewardFee();
@@ -479,9 +469,9 @@ describe('Aura Spell', () => {
               strategyId: 0,
               collToken: CRV,
               borrowToken: USDC,
-              amountRepay: debtAmount.div(2),
+              amountRepay: 0,
               amountPosRemove: position.collateralSize.div(2),
-              amountShareWithdraw: position.underlyingVaultShare.div(2),
+              amountShareWithdraw: 0,
               amountOutMin: 1,
               amountToSwap,
               swapData,
@@ -497,9 +487,7 @@ describe('Aura Spell', () => {
       await evm_mine_blocks(1000);
       const positionId = (await bank.getNextPositionId()).sub(1);
       const position = await bank.getPositionInfo(positionId);
-
-      const totalEarned = await auraRewarder.earned(waura.address);
-      console.log('Wrapper Total Earned:', utils.formatUnits(totalEarned));
+      const iface = new ethers.utils.Interface(SpellABI);
 
       const pendingRewardsInfo = await waura.callStatic.pendingRewards(position.collId, position.collateralSize);
 
@@ -520,9 +508,6 @@ describe('Aura Spell', () => {
           }
         })
       );
-
-      console.log('Pending Rewards', pendingRewardsInfo);
-
       // Manually transfer CRV rewards to spell
       //await usdc.transfer(spell.address, utils.parseUnits("10", 6))
       const amountToSwap = utils.parseUnits('30', 18);
@@ -532,7 +517,6 @@ describe('Aura Spell', () => {
       const beforeUSDCBalance = await usdc.balanceOf(admin.address);
       const beforeCrvBalance = await crv.balanceOf(admin.address);
 
-      const iface = new ethers.utils.Interface(SpellABI);
       await bank.execute(
         positionId,
         spell.address,
@@ -554,8 +538,7 @@ describe('Aura Spell', () => {
       );
       const afterUSDCBalance = await usdc.balanceOf(admin.address);
       const afterCrvBalance = await crv.balanceOf(admin.address);
-      console.log('USDC Balance Change:', afterUSDCBalance.sub(beforeUSDCBalance));
-      console.log('CRV Balance Change:', afterCrvBalance.sub(beforeCrvBalance));
+
       const depositFee = depositAmount.mul(50).div(10000);
       const withdrawFee = depositAmount.sub(depositFee).mul(50).div(10000);
       expect(afterCrvBalance.sub(beforeCrvBalance)).to.be.gte(

--- a/test/spell/strategies/aura/aura.test.ts
+++ b/test/spell/strategies/aura/aura.test.ts
@@ -90,9 +90,7 @@ describe('Aura Spell Strategy test', () => {
               await ethers.getContractAt('ICvxExtraRewarder', await auraRewarder.extraRewards(0))
             );
 
-            stashToken = <IStashToken>(
-              await ethers.getContractAt('IStashToken', await extraRewarder1.rewardToken())
-            );
+            stashToken = <IStashToken>await ethers.getContractAt('IStashToken', await extraRewarder1.rewardToken());
 
             await setTokenBalance(collateralToken, alice, utils.parseEther('1000000000000'));
             await setTokenBalance(collateralToken, bob, utils.parseEther('1000000000000'));
@@ -274,26 +272,26 @@ describe('Aura Spell Strategy test', () => {
             extraRewarder2 = <MockVirtualBalanceRewardPool>(
               await rewarderFactory.deploy(auraRewarder.address, dai.address)
             );
-            console.log('Extra rewarder 2 address:', extraRewarder2.address);
+
             await auraRewarder.connect(rewardManager).addExtraReward(extraRewarder2.address);
-            console.log('Extra rewarder 2 added');
+
             const pid = BigNumber.from(strategyInfo.poolId);
 
             const extraRewardLength = await waura.extraRewardsLength(pid);
             await waura.syncExtraRewards(pid, position.collId);
 
             expect(await waura.extraRewardsLength(pid)).greaterThan(extraRewardLength);
-            
+
             const pendingRewardsInfoAfterAdd = await waura.pendingRewards(position.collId, position.collateralSize);
-            console.log('Pending rewards info after add:', pendingRewardsInfoAfterAdd);
+
             const expectedAmounts = pendingRewardsInfoAfterAdd.rewards.map((reward: BigNumber) => reward);
-            
+
             const swapDatas = pendingRewardsInfoAfterAdd.tokens.map((token: any, i: any) => ({
               data: '0x',
             }));
-            console.log('setTokenBalance');
+
             await setTokenBalance(borrowToken, spell, utils.parseEther('1000'));
-            console.log('Closing position');
+
             await closePosition(
               alice,
               positionId,

--- a/test/spell/strategies/aura/aura.test.ts
+++ b/test/spell/strategies/aura/aura.test.ts
@@ -12,7 +12,7 @@ import {
   IRewarder,
   ICvxExtraRewarder,
   ProtocolConfig,
-  IAuraStashToken,
+  IStashToken,
   MockVirtualBalanceRewardPool,
 } from '../../../../typechain-types';
 import { ADDRESS } from '../../../../constant';
@@ -48,7 +48,7 @@ describe('Aura Spell Strategy test', () => {
   let rewardFeePct: BigNumber;
   let extraRewarder1: ICvxExtraRewarder;
   let extraRewarder2: MockVirtualBalanceRewardPool;
-  let stashToken: IAuraStashToken;
+  let stashToken: IStashToken;
 
   before(async () => {
     await fork();
@@ -90,8 +90,8 @@ describe('Aura Spell Strategy test', () => {
               await ethers.getContractAt('ICvxExtraRewarder', await auraRewarder.extraRewards(0))
             );
 
-            stashToken = <IAuraStashToken>(
-              await ethers.getContractAt('IAuraStashToken', await extraRewarder1.rewardToken())
+            stashToken = <IStashToken>(
+              await ethers.getContractAt('IStashToken', await extraRewarder1.rewardToken())
             );
 
             await setTokenBalance(collateralToken, alice, utils.parseEther('1000000000000'));
@@ -274,27 +274,26 @@ describe('Aura Spell Strategy test', () => {
             extraRewarder2 = <MockVirtualBalanceRewardPool>(
               await rewarderFactory.deploy(auraRewarder.address, dai.address)
             );
-
+            console.log('Extra rewarder 2 address:', extraRewarder2.address);
             await auraRewarder.connect(rewardManager).addExtraReward(extraRewarder2.address);
-
+            console.log('Extra rewarder 2 added');
             const pid = BigNumber.from(strategyInfo.poolId);
 
             const extraRewardLength = await waura.extraRewardsLength(pid);
             await waura.syncExtraRewards(pid, position.collId);
 
             expect(await waura.extraRewardsLength(pid)).greaterThan(extraRewardLength);
-
+            
             const pendingRewardsInfoAfterAdd = await waura.pendingRewards(position.collId, position.collateralSize);
-
-            expect(pendingRewardsInfoAfterAdd.rewards.length).gte(pendingRewardsInfo.rewards.length);
-
+            console.log('Pending rewards info after add:', pendingRewardsInfoAfterAdd);
             const expectedAmounts = pendingRewardsInfoAfterAdd.rewards.map((reward: BigNumber) => reward);
-
+            
             const swapDatas = pendingRewardsInfoAfterAdd.tokens.map((token: any, i: any) => ({
               data: '0x',
             }));
+            console.log('setTokenBalance');
             await setTokenBalance(borrowToken, spell, utils.parseEther('1000'));
-
+            console.log('Closing position');
             await closePosition(
               alice,
               positionId,


### PR DESCRIPTION
# Description

The original `wAuraBooster` contract did not account for the fact that all extra reward tokens are considered stash tokens. This update makes this adjustment by calling `baseToken` on all extra reward tokens in order to further unwrap the asset.

## Type of change

- [x] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests are included for all code paths
- [x] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->