### PR TITLE
[L-03] BlueberryBank.execute() might calculate risk using stale data.

### DIFF
--- a/contracts/BlueberryBank.sol
+++ b/contracts/BlueberryBank.sol
@@ -232,6 +232,7 @@ contract BlueberryBank is IBank, Ownable2StepUpgradeable, ERC1155NaiveReceiver {
             }
         }
 
+        accrue(_positions[positionId].underlyingToken);
         if (isLiquidatable(positionId)) revert Errors.INSUFFICIENT_COLLATERAL();
 
         _POSITION_ID = _NO_ID;

--- a/test/money-market/bToken.test.ts
+++ b/test/money-market/bToken.test.ts
@@ -53,7 +53,6 @@ describe('BToken Money Market', () => {
       await bTokenAdmin._setSoftVault(bUSDC.address, softVault.address);
       await bTokenAdmin._setSoftVault(bWETH.address, softVault.address);
 
-
       await usdc.connect(softVault).approve(bUSDC.address, amount);
       let success = await bUSDC.connect(softVault).callStatic.mint(amount);
       expect(success).to.equal(0);
@@ -77,7 +76,6 @@ describe('BToken Money Market', () => {
       await comptroller._setCreditLimit(bank.address, bWETH.address, amount);
 
       amount = ethers.BigNumber.from(10);
-
 
       await usdc.connect(softVault).approve(bUSDC.address, amount);
       await bUSDC.connect(softVault).mint(amount);


### PR DESCRIPTION
# Description

Within the architecture of Blueberry V1, a lot of important logic is off-loaded to the spell's. As noted in @cuthalion0x last audit of Blueberry, the `BlueberryBank` indirectly calls `BErc20.accrueInterest()` through the associated spell implementation. This call is extremely important to ensure the accuracy of interest data, which affects the health of a position. In most situations, `accrue` will be called every time a spell is interacted with, but there is one instance where if a users performs a partial close on a position and does not withdraw any of their isolated collateral, `accrue` will not be triggered. In order to mitigate this we will call `accrue` before checking if a `positionId` `isLiquidatable` to safeguard users from putting their position underwater.

## Type of change

- [x] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests are included for all code paths
- [x] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->