### PR TITLE
[L-02] Users can create outsized positions by front-running AuraSpell.openPositionFarm().

### DIFF
--- a/contracts/spell/AuraSpell.sol
+++ b/contracts/spell/AuraSpell.sol
@@ -284,8 +284,8 @@ contract AuraSpell is IAuraSpell, BasicSpell {
 
         for (i; i < length; ++i) {
             if (tokens[i] != lpToken) {
-                amountsIn[j] = tokens[i] == borrowToken ? borrowAmount : 0;
-                if (amountsIn[j] > 0) {
+                if (tokens[i] == borrowToken) {
+                    amountsIn[j] = borrowAmount;
                     IERC20(tokens[i]).universalApprove(vault, amountsIn[j]);
                     maxAmountsIn[i] = amountsIn[j];
                 }

--- a/contracts/spell/AuraSpell.sol
+++ b/contracts/spell/AuraSpell.sol
@@ -105,8 +105,11 @@ contract AuraSpell is IAuraSpell, BasicSpell {
         /// 1. Deposit isolated collaterals on Blueberry Money Market
         _doLend(param.collToken, param.collAmount);
 
+        address borrowToken = param.borrowToken;
+        uint256 borrowAmount = param.borrowAmount;
+
         /// 2. Borrow funds based on specified amount
-        _doBorrow(param.borrowToken, param.borrowAmount);
+        _doBorrow(borrowToken, borrowAmount);
 
         /// 3. Add liquidity to the Balancer pool and receive BPT in return.
         {
@@ -117,7 +120,9 @@ contract AuraSpell is IAuraSpell, BasicSpell {
             (uint256[] memory maxAmountsIn, uint256[] memory amountsIn) = _getJoinPoolParamsAndApprove(
                 address(vault),
                 tokens,
-                lpToken
+                lpToken,
+                borrowToken,
+                borrowAmount
             );
 
             vault.joinPool(
@@ -266,7 +271,9 @@ contract AuraSpell is IAuraSpell, BasicSpell {
     function _getJoinPoolParamsAndApprove(
         address vault,
         address[] memory tokens,
-        address lpToken
+        address lpToken,
+        address borrowToken,
+        uint256 borrowAmount
     ) internal returns (uint256[] memory, uint256[] memory) {
         uint256 i;
         uint256 j;
@@ -277,7 +284,7 @@ contract AuraSpell is IAuraSpell, BasicSpell {
 
         for (i; i < length; ++i) {
             if (tokens[i] != lpToken) {
-                amountsIn[j] = IERC20(tokens[i]).balanceOf(address(this));
+                amountsIn[j] = tokens[i] == borrowToken ? borrowAmount : 0;
                 if (amountsIn[j] > 0) {
                     IERC20(tokens[i]).universalApprove(vault, amountsIn[j]);
                     maxAmountsIn[i] = amountsIn[j];

--- a/test/money-market/bToken.test.ts
+++ b/test/money-market/bToken.test.ts
@@ -53,7 +53,6 @@ describe('BToken Money Market', () => {
       await bTokenAdmin._setSoftVault(bUSDC.address, softVault.address);
       await bTokenAdmin._setSoftVault(bWETH.address, softVault.address);
 
-
       await usdc.connect(softVault).approve(bUSDC.address, amount);
       let success = await bUSDC.connect(softVault).callStatic.mint(amount);
       expect(success).to.equal(0);
@@ -77,7 +76,6 @@ describe('BToken Money Market', () => {
       await comptroller._setCreditLimit(bank.address, bWETH.address, amount);
 
       amount = ethers.BigNumber.from(10);
-
 
       await usdc.connect(softVault).approve(bUSDC.address, amount);
       await bUSDC.connect(softVault).mint(amount);

--- a/test/spell/aura.spell.test.ts
+++ b/test/spell/aura.spell.test.ts
@@ -5,8 +5,6 @@ import {
   WERC20,
   ERC20,
   WAuraBooster,
-  IAuraBooster,
-  IRewarder,
   AuraSpell,
   ProtocolConfig,
 } from '../../typechain-types';
@@ -48,9 +46,7 @@ describe('Aura Spell', () => {
   let waura: WAuraBooster;
   let bank: BlueberryBank;
   let protocol: AuraProtocol;
-  let auraBooster: IAuraBooster;
   let config: ProtocolConfig;
-  let auraRewarder: IRewarder;
 
   before(async () => {
     await fork();
@@ -61,9 +57,6 @@ describe('Aura Spell', () => {
     aura = <ERC20>await ethers.getContractAt('ERC20', AURA);
     bal = <ERC20>await ethers.getContractAt('ERC20', BAL);
     usdc = <ERC20>await ethers.getContractAt('ERC20', USDC);
-    auraBooster = <IAuraBooster>await ethers.getContractAt('IAuraBooster', ADDRESS.AURA_BOOSTER);
-    const poolInfo = await auraBooster.poolInfo(ADDRESS.AURA_UDU_POOL_ID);
-    auraRewarder = <IRewarder>await ethers.getContractAt('IRewarder', poolInfo.crvRewards);
 
     protocol = await setupAuraProtocol();
     bank = protocol.bank;

--- a/test/spell/aura.spell.test.ts
+++ b/test/spell/aura.spell.test.ts
@@ -50,6 +50,7 @@ describe('Aura Spell', () => {
   let protocol: AuraProtocol;
   let auraBooster: IAuraBooster;
   let config: ProtocolConfig;
+  let auraRewarder: IRewarder;
 
   before(async () => {
     await fork();


### PR DESCRIPTION
# Description

Within the `AuraSpell`, `_getJoinPoolParamsAndApprove` seta the `tokens` and `maxAmountsIn` arrays for executing a single side join into a Balancer pool. It does so by iterating through the list of pool tokens and setting the amounts to the contracts live balance. This is both inefficient and creates a situation where users can front-run their own call in order to increase the value of their position. While this does not create negative consequences for Blueberry the protocol itself it breaks the implied invariant that position value should be closely equal to the users debt value when opening a position. In order to eliminate this frontrun possibility as well as decrease the number of external calls we should instead set all token amounts to 0 except for the borrowToken which we should set to `param.borrowAmount`.

Documentation finding [I-08] Avoid hard-coding values that have no meaning to the reader, is also solved in this PR. 

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [ ] The diff is legible and has no extraneous changes
- [ ] Complex code has been commented, including external interfaces
- [ ] Tests are included for all code paths
- [ ] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->