### PR TITLE
Emergency Funds within Liquidator Bot

### DIFF
--- a/contracts/liquidation/AuraLiquidator.sol
+++ b/contracts/liquidation/AuraLiquidator.sol
@@ -58,6 +58,7 @@ contract AuraLiquidator is BaseLiquidator {
     function initialize(
         IBank bank,
         address treasury,
+        address emergencyFund,
         address poolAddressesProvider,
         address auraSpell,
         address balancerVault,
@@ -77,6 +78,7 @@ contract AuraLiquidator is BaseLiquidator {
         _swapRouter = swapRouter;
         _weth = weth;
 
+        _emergencyFund = emergencyFund;
         _transferOwnership(owner);
     }
 

--- a/contracts/liquidation/BaseLiquidator.sol
+++ b/contracts/liquidation/BaseLiquidator.sol
@@ -161,6 +161,15 @@ abstract contract BaseLiquidator is IBlueberryLiquidator, SwapRegistry, IERC1155
     }
 
     /**
+     * @notice Sets the address of the emergency fund
+     * @param emergencyFund The address of the emergency fund
+     */
+    function setEmergencyFund(address emergencyFund) external onlyOwner {
+        if (emergencyFund != address(0)) revert Errors.ZERO_ADDRESS();
+        _emergencyFund = emergencyFund;
+    }
+
+    /**
      * @notice Sends emergency funds to the contract to cover unprofitable liquidations
      * @param asset The address of the asset to withdraw from the contract
      * @param amount Amount of asset to send to the liquidator bot

--- a/contracts/liquidation/BaseLiquidator.sol
+++ b/contracts/liquidation/BaseLiquidator.sol
@@ -165,7 +165,7 @@ abstract contract BaseLiquidator is IBlueberryLiquidator, SwapRegistry, IERC1155
      * @param emergencyFund The address of the emergency fund
      */
     function setEmergencyFund(address emergencyFund) external onlyOwner {
-        if (emergencyFund != address(0)) revert Errors.ZERO_ADDRESS();
+        if (emergencyFund == address(0)) revert Errors.ZERO_ADDRESS();
         _emergencyFund = emergencyFund;
     }
 

--- a/contracts/liquidation/BaseLiquidator.sol
+++ b/contracts/liquidation/BaseLiquidator.sol
@@ -140,7 +140,7 @@ abstract contract BaseLiquidator is IBlueberryLiquidator, SwapRegistry, IERC1155
         // Have the emergency fund cover any extra costs
         uint256 assetBalance = IERC20(asset).balanceOf(address(this));
         if (assetBalance < amount + premium) {
-            _accessEmergencyFunds(asset, assetBalance - (amount + premium));
+            _accessEmergencyFunds(asset, (amount + premium) - assetBalance);
         }
 
         // reset position id

--- a/contracts/liquidation/BaseLiquidator.sol
+++ b/contracts/liquidation/BaseLiquidator.sol
@@ -51,6 +51,9 @@ abstract contract BaseLiquidator is IBlueberryLiquidator, SwapRegistry, IERC1155
     /// @dev aave pool addresses provider
     IPoolAddressesProvider private _poolAddressesProvider;
 
+    /// @dev The address of the emergency fund that will cover any extra costs for liquidation
+    address internal _emergencyFund;
+
     /*//////////////////////////////////////////////////////////////////////////
                                       FUNCTIONS
     //////////////////////////////////////////////////////////////////////////*/
@@ -134,6 +137,12 @@ abstract contract BaseLiquidator is IBlueberryLiquidator, SwapRegistry, IERC1155
         // forceApprove aave pool to get back debt
         IERC20(asset).forceApprove(address(_pool), amount + premium);
 
+        // Have the emergency fund cover any extra costs
+        uint256 assetBalance = IERC20(asset).balanceOf(address(this));
+        if (assetBalance < amount + premium) {
+            _accessEmergencyFunds(asset, assetBalance - (amount + premium));
+        }
+
         // reset position id
         _POS_ID = 0;
 
@@ -149,6 +158,15 @@ abstract contract BaseLiquidator is IBlueberryLiquidator, SwapRegistry, IERC1155
             IERC20 token = IERC20(tokens[i]);
             token.transfer(_treasury, token.balanceOf(address(this)));
         }
+    }
+
+    /**
+     * @notice Sends emergency funds to the contract to cover unprofitable liquidations
+     * @param asset The address of the asset to withdraw from the contract
+     * @param amount Amount of asset to send to the liquidator bot
+     */
+    function _accessEmergencyFunds(address asset, uint256 amount) internal {
+        IERC20(asset).transferFrom(_emergencyFund, address(this), amount);
     }
 
     /**

--- a/contracts/liquidation/ConvexLiquidator.sol
+++ b/contracts/liquidation/ConvexLiquidator.sol
@@ -63,6 +63,7 @@ contract ConvexLiquidator is BaseLiquidator {
     function initialize(
         IBank bank,
         address treasury,
+        address emergencyFund,
         address poolAddressesProvider,
         address convexSpell,
         address balancerVault,
@@ -83,6 +84,8 @@ contract ConvexLiquidator is BaseLiquidator {
         _curveOracle = IConvexSpell(convexSpell).getCrvOracle();
 
         _weth = weth;
+        _emergencyFund = emergencyFund;
+
         _transferOwnership(owner);
     }
 

--- a/contracts/liquidation/IchiLiquidator.sol
+++ b/contracts/liquidation/IchiLiquidator.sol
@@ -58,6 +58,7 @@ contract IchiLiquidator is BaseLiquidator {
     function initialize(
         IBank bank,
         address treasury,
+        address emergencyFund,
         address poolAddressesProvider,
         address ichiSpell,
         address swapRouter,
@@ -77,6 +78,7 @@ contract IchiLiquidator is BaseLiquidator {
         _swapRouter = swapRouter;
         _weth = weth;
 
+        _emergencyFund = emergencyFund;
         _transferOwnership(owner);
     }
 
@@ -118,7 +120,8 @@ contract IchiLiquidator is BaseLiquidator {
     function _unwrapLpToken(IBank.Position memory posInfo) internal returns (address) {
         // Withdraw ERC1155 liquidiation
         if (posInfo.collToken == address(IIchiSpell(_spell).getWIchiFarm())) {
-            IWIchiFarm(posInfo.collToken).burn(posInfo.collId, type(uint256).max);
+            uint256 balance = IERC1155(posInfo.collToken).balanceOf(address(this), posInfo.collId);
+            IWIchiFarm(posInfo.collToken).burn(posInfo.collId, balance);
             (uint256 pid, ) = IWIchiFarm(posInfo.collToken).decodeId(posInfo.collId);
 
             return IIchiFarm(IWIchiFarm(posInfo.collToken).getIchiFarm()).lpToken(pid);

--- a/contracts/liquidation/ShortLongLiquidator.sol
+++ b/contracts/liquidation/ShortLongLiquidator.sol
@@ -50,6 +50,7 @@ contract ShortLongLiquidator is BaseLiquidator {
     function initialize(
         IBank bank,
         address treasury,
+        address emergencyFund,
         address poolAddressesProvider,
         address shortLongSpell,
         address balancerVault,
@@ -67,6 +68,7 @@ contract ShortLongLiquidator is BaseLiquidator {
         _balancerVault = balancerVault;
         _swapRouter = swapRouter;
         _weth = weth;
+        _emergencyFund = emergencyFund;
         _transferOwnership(owner);
     }
 

--- a/test/liquidator/AuraLiquidation.test.ts
+++ b/test/liquidator/AuraLiquidation.test.ts
@@ -24,6 +24,7 @@ describe('Aura Liquidator', () => {
   let admin: SignerWithAddress;
   let alice: SignerWithAddress;
   let treasury: SignerWithAddress;
+  let emergengyFund: SignerWithAddress;
 
   let usdc: ERC20;
   let dai: ERC20;
@@ -37,7 +38,7 @@ describe('Aura Liquidator', () => {
   before(async () => {
     await fork();
 
-    [admin, alice, treasury] = await ethers.getSigners();
+    [admin, alice, treasury, emergengyFund] = await ethers.getSigners();
     usdc = <ERC20>await ethers.getContractAt('ERC20', USDC);
     usdc = <ERC20>await ethers.getContractAt('ERC20', USDC);
     dai = <ERC20>await ethers.getContractAt('ERC20', DAI);
@@ -77,6 +78,7 @@ describe('Aura Liquidator', () => {
       [
         bank.address,
         treasury.address,
+        emergengyFund.address,
         POOL_ADDRESSES_PROVIDER,
         spell.address,
         BALANCER_VAULT,

--- a/test/liquidator/ConvexLiquidation.test.ts
+++ b/test/liquidator/ConvexLiquidation.test.ts
@@ -28,6 +28,7 @@ describe('Convex Liquidator', () => {
   let admin: SignerWithAddress;
   let alice: SignerWithAddress;
   let treasury: SignerWithAddress;
+  let emergengyFund: SignerWithAddress;
 
   let usdc: ERC20;
   let mockOracle: MockOracle;
@@ -40,7 +41,7 @@ describe('Convex Liquidator', () => {
 
   before(async () => {
     await fork(1);
-    [admin, alice, treasury] = await ethers.getSigners();
+    [admin, alice, treasury, emergengyFund] = await ethers.getSigners();
     usdc = <ERC20>await ethers.getContractAt('ERC20', USDC);
     dai = <ERC20>await ethers.getContractAt('ERC20', DAI);
     usdc = <ERC20>await ethers.getContractAt('ERC20', USDC);
@@ -80,6 +81,7 @@ describe('Convex Liquidator', () => {
       [
         bank.address,
         treasury.address,
+        emergengyFund.address,
         POOL_ADDRESSES_PROVIDER,
         spell.address,
         BALANCER_VAULT,

--- a/test/liquidator/IchiLiquidator.test.ts
+++ b/test/liquidator/IchiLiquidator.test.ts
@@ -34,6 +34,7 @@ describe('Ichi Liquidator', () => {
   let admin: SignerWithAddress;
   let alice: SignerWithAddress;
   let treasury: SignerWithAddress;
+  let emergengyFund: SignerWithAddress;
 
   let usdc: ERC20;
   let ichi: MockIchiV2;
@@ -50,7 +51,7 @@ describe('Ichi Liquidator', () => {
   before(async () => {
     await fork();
 
-    [admin, alice, treasury] = await ethers.getSigners();
+    [admin, alice, treasury, emergengyFund] = await ethers.getSigners();
     usdc = <ERC20>await ethers.getContractAt('ERC20', USDC);
     ichi = <MockIchiV2>await ethers.getContractAt('MockIchiV2', ICHI);
     ichiV1 = <ERC20>await ethers.getContractAt('ERC20', ICHIV1);
@@ -95,6 +96,7 @@ describe('Ichi Liquidator', () => {
       [
         bank.address,
         treasury.address,
+        emergengyFund.address,
         POOL_ADDRESSES_PROVIDER,
         spell.address,
         UNISWAP_V3_ROUTER,

--- a/test/liquidator/ShortLongLiquidator.test.ts
+++ b/test/liquidator/ShortLongLiquidator.test.ts
@@ -21,6 +21,7 @@ describe('ShortLong Liquidator', () => {
   let admin: SignerWithAddress;
   let alice: SignerWithAddress;
   let treasury: SignerWithAddress;
+  let emergengyFund: SignerWithAddress;
 
   let usdc: ERC20;
   let crv: ERC20;
@@ -31,7 +32,7 @@ describe('ShortLong Liquidator', () => {
   let positionId: BigNumber;
 
   before(async () => {
-    [admin, alice, treasury] = await ethers.getSigners();
+    [admin, alice, treasury, emergengyFund] = await ethers.getSigners();
     usdc = <ERC20>await ethers.getContractAt('ERC20', USDC);
     crv = <ERC20>await ethers.getContractAt('ERC20', CRV);
     const protocol = await setupShortLongProtocol();
@@ -46,6 +47,7 @@ describe('ShortLong Liquidator', () => {
       [
         bank.address,
         treasury.address,
+        emergengyFund.address,
         POOL_ADDRESSES_PROVIDER,
         spell.address,
         BALANCER_VAULT,


### PR DESCRIPTION
# Description

This PR helps decrease the risk of bad debt in the system by adding `_accessEmergencyFunds` which transfers tokens from an `emergencyFund` wallet to the liquidator bot in the event that the balance of the Liquidator is less than the flash loan repayment amount. Previously this bot only supported profitable liquidations but now can handle unprofitable liquidations as well.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [x] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests are included for all code paths
- [x] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->